### PR TITLE
Add handling of lab repos with no workshop dir

### DIFF
--- a/aggregate-labs.sh
+++ b/aggregate-labs.sh
@@ -14,7 +14,12 @@ do_the_thing(){
         echo "adding $repo to agenda"
         workshopName=$(basename "$repo")
     	git clone "$repo" tempClones/"$workshopName"
-    	cp -a tempClones/"$workshopName"/workshop workshop/generatedContent/"$workshopName"
+        if [[ -d tempClones/"$workshopName"/workshop ]]; then
+            cp -a tempClones/"$workshopName"/workshop workshop/generatedContent/"$workshopName"
+        else
+            rm -rf tempClones/"$workshopName"/.git*
+            cp -a tempClones/"$workshopName" workshop/generatedContent/"$workshopName"
+        fi
     	echo "* [generatedContent/$workshopName](generatedContent/$workshopName/README.md)" >> workshop/generatedContentLinks.md
     	for lab in workshop/generatedContent/"$workshopName"/*/*; do
             [[ -d "$lab" ]] || break


### PR DESCRIPTION
Previously, the aggregate-labs.sh script would fail if there was no
workshop directory in the lab repo. Now the script handles that as
simply as possible.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>