### PR TITLE
Aggregation script improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+---
+language: node_js
+node_js: 10
+
+before_script:
+  - npm install markdownlint-cli
+script:
+  - markdownlint -c .markdownlint.json workshop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-language: node_js
-node_js: 10
-
-before_script:
-  - npm install markdownlint-cli
-script:
-  - markdownlint -c .markdownlint.json workshop

--- a/agenda.yaml
+++ b/agenda.yaml
@@ -1,0 +1,11 @@
+# Add repo URLs for labs in this format
+repos:
+    - url: URL TO REPO
+    - url: SECOND URL TO REPO
+      branch: BRANCH TO CHECK OUT (OPTIONAL)
+        
+
+
+
+
+

--- a/aggregate-labs.sh
+++ b/aggregate-labs.sh
@@ -10,37 +10,89 @@ clean_generatedContent(){
 }
 
 do_the_thing(){
-    grep -v '^ *#' < agenda.txt | while IFS= read -r repo; do
-        echo "adding $repo to agenda"
-        workshopName=$(basename "$repo")
-    	git clone "$repo" tempClones/"$workshopName"
-        if [[ -d tempClones/"$workshopName"/workshop ]]; then
-            cp -a tempClones/"$workshopName"/workshop workshop/generatedContent/"$workshopName"
-        else
-            rm -rf tempClones/"$workshopName"/.git*
-            cp -a tempClones/"$workshopName" workshop/generatedContent/"$workshopName"
+    
+    for repoPath in `yq r agenda.yaml --printMode p "repos.*"`; do
+
+        repo=`yq r agenda.yaml --printMode v "$repoPath.url"`
+        BRANCH=`yq r agenda.yaml --printMode v "$repoPath.branch"`
+        if [[ -z $BRANCH ]]; then
+            BRANCH="master"
         fi
-    	echo "* [generatedContent/$workshopName](generatedContent/$workshopName/README.md)" >> workshop/generatedContentLinks.md
-    	for lab in workshop/generatedContent/"$workshopName"/*/*; do
-            [[ -d "$lab" ]] || break
-    		labName=$(basename "$lab")
-    		echo "    * [generatedContent/$workshopName/$labName](generatedContent/$workshopName/$labName/README.md)" >> workshop/generatedContentLinks.md
-    		echo "Lab -> $(basename "$lab")"
-    	done
-    	echo "This content is generated! Do not edit directly! Please run aggregate-labs.sh to repopulate with latest content from agenda.txt!" > workshop/generatedContent/README.md
+
+        echo ""
+        echo "Cloning $repo..."
+        workshopName=$(basename "$repo")
+    	git clone --quiet "$repo" tempClones/"$workshopName"
+
+        cd tempClones/"$workshopName"
+        echo "Checking out branch $BRANCH..."
+        git checkout --quiet $BRANCH
+        cd ../..
+
+        GITBOOK_YAML="tempClones/"$workshopName"/.gitbook.yaml"
+        if [[ -z $GITBOOK_YAML ]]; then
+            echo "Not a gitbook... skipping!"
+            continue
+        fi
+
+        GITBOOK_ROOT=`yq r tempClones/"$workshopName"/.gitbook.yaml root`
+        if [[ -z "GITBOOK_ROOT" ]]; then
+            echo "Error reading gitbook... skipping!"
+            continue
+        fi
+        echo "Found Gitbook root at $GITBOOK_ROOT"
+
+
+        CLONED_REPO_ROOT=tempClones/"$workshopName"
+        WORKSHOP_PATH="$CLONED_REPO_ROOT"/"$GITBOOK_ROOT"
+
+        echo "Cleaning up any .git files from cloned repo"
+        rm -rf "$CLONED_REPO_ROOT"/.git*
+
+
+        GENERATED_CONTENT_PATH=workshop/generatedContent/"$workshopName"
+        echo "Copying over content to $GENERATED_CONTENT_PATH"
+        if [[ -d $WORKSHOP_PATH ]]; then
+            cp -a $WORKSHOP_PATH $GENERATED_CONTENT_PATH
+        else
+            cp -a $CLONED_REPO_ROOT $GENERATED_CONTENT_PATH
+        fi
+
+        GENERATED_CONTENT_LINKS_MD="workshop/generatedContentLinks.md"
+        echo "Generating links in $GENERATED_CONTENT_LINKS_MD"
+
+        printf "###############################\n" >> $GENERATED_CONTENT_LINKS_MD
+        printf "##  SUMMARY.md for $workshopName\n" >> $GENERATED_CONTENT_LINKS_MD
+        printf "################################\n\n" >> $GENERATED_CONTENT_LINKS_MD
+        printf "# Home Page for Gitbook \n" >> $GENERATED_CONTENT_LINKS_MD
+        printf "* [$workshopName](generatedContent/$workshopName/README.md)\n\n" >> $GENERATED_CONTENT_LINKS_MD
+
+	    SUMMARY_MD="$GENERATED_CONTENT_PATH"/SUMMARY.md
+        if [[ -f $SUMMARY_MD ]]; then
+            sed "s/\[\(.*\)\](\(.*\))/\[\1\](generatedContent\/$workshopName\/\2)/" $SUMMARY_MD >> $GENERATED_CONTENT_LINKS_MD
+        fi
+
+        printf "\n\n" >> $GENERATED_CONTENT_LINKS_MD
+
+
     done
+
+    echo "This content is generated! Do not edit directly! Please run aggregate-labs.sh to repopulate with latest content from agenda.txt!" > workshop/generatedContent/README.md
+
 }
 
 main(){
-    pushd "$(dirname "$0")" || exit 1
+    pushd "$(dirname "$0")" > /dev/null || exit 1
+    command -v yq >/dev/null 2>&1 || { echo >&2 "This script requires yq but it's not installed.  Aborting."; exit 1; }
     if [[ -d tempClones ]]; then
         clean_tempClones
      fi
     mkdir -p tempClones workshop/generatedContent
     clean_generatedContent
+    printf "THIS FILE CONTAINS ALL THE SUMMARY.MDs OF THE GENERATED CONTENT PREFIXED WITH RIGHT PATH (\"generatedContent\") SO THAT YOU CAN COPY AND PASTE THIS INTO THE PARENT SUMMARY.MD" >> workshop/generatedContentLinks.md
     do_the_thing
     clean_tempClones
-    popd || exit 1
+    popd > /dev/null || exit 1
 }
 
 main


### PR DESCRIPTION
- read from agenda.yaml instead of agenda.txt which allows us to specific a specific branch to use on the target repot
- check .gitbook.yaml on target and copy over content at the root
- copy the SUMMARY.md contents over to generatedContentLinks.md with the path fixed with the new location of the content so that we can copy and paste to the main summary easily.